### PR TITLE
Fixing Run2 to campaign mapping, script to print yields

### DIFF
--- a/src/plotter/atlas.py
+++ b/src/plotter/atlas.py
@@ -135,7 +135,7 @@ def get_year2campaign() -> Dict[str, str]:
     """Returns dict per mc campaign which
     maps year to campaign."""
     year2campaign = {
-        "": "",  # all years = all campaigns
+        "Run2": "",  # all years = all campaigns
         "1516": ".mc16a",
         "17": ".mc16d",
         "18": ".mc16e",

--- a/src/plotter/pdgRounding.py
+++ b/src/plotter/pdgRounding.py
@@ -1,0 +1,67 @@
+#!/bin/env python
+
+# This class implements the pdg rounding rules indicated in
+# section 5.3 of doi:10.1088/0954-3899/33/1/001
+#
+# Note: because it uses round (and in general floats), it is affected
+# by the limitations described in
+# http://docs.python.org/library/functions.html#round
+#  and
+# http://dx.doi.org/10.1145/103162.103163
+#
+# davide.gerbaudo@gmail.com
+# September 2012
+
+#Taken from: https://github.com/gerbaudo/python-scripts/blob/master/various/pdgRounding.py
+
+def pdgRound(value, error) :
+    "Given a value and an error, round and format them according to the PDG rules for significant digits"
+    def threeDigits(value) :
+        "extract the three most significant digits and return them as an int"
+        return int(("%.2e"%float(error)).split('e')[0].replace('.','').replace('+','').replace('-',''))
+    def nSignificantDigits(threeDigits) :
+        assert threeDigits<1000,"three digits (%d) cannot be larger than 10^3"%threeDigits
+        if threeDigits<101 : return 2 # not sure
+        elif threeDigits<356 : return 2
+        elif threeDigits<950 : return 1
+        else : return 2
+    def frexp10(value) :
+        "convert to mantissa+exp representation (same as frex, but in base 10)"
+        valueStr = ("%e"%float(value)).split('e')
+        return float(valueStr[0]), int(valueStr[1])
+    def nDigitsValue(expVal, expErr, nDigitsErr) :
+        "compute the number of digits we want for the value, assuming we keep nDigitsErr for the error"
+        return expVal-expErr+nDigitsErr
+    def formatValue(value, exponent, nDigits, extraRound=0) :
+        "Format the value; extraRound is meant for the special case of threeDigits>950"
+        roundAt = nDigits-1-exponent - extraRound
+        nDec = roundAt if exponent<nDigits else 0
+        nDec = max([nDec, 0])
+        return ('%.'+str(nDec)+'f')%round(value,roundAt)
+    tD = threeDigits(error)
+    nD = nSignificantDigits(tD)
+    expVal, expErr = frexp10(value)[1], frexp10(error)[1]
+    extraRound = 1 if tD>=950 else 0
+    return (formatValue(value, expVal, nDigitsValue(expVal, expErr, nD), extraRound),
+            formatValue(error,expErr, nD, extraRound))
+
+"""
+def test(valueError=(0., 0.)) :
+    val, err = valueError
+    print val,' +/- ',err,' --> ',
+    val, err = pdgRound(val, err)
+    print ' ',val,' +/- ',err
+
+if __name__=='__main__' :
+    for x in [(0.827, 0.119121212)
+              ,(0.827, 0.3676565)
+              ,(0.827, 0.952)
+              ,(1.2345e7, 67890.1e2)
+              ,(1.2345e7, 54321.1e2)
+              ,(1.2345e7, 32100.1e2)
+              ,(0.00827, 0.0000123)
+              ,(0.00827, 0.0000456)
+              ,(0.00827, 0.0000952)
+              ,(225.651, 96.1938)
+              ] : test(x)
+"""

--- a/src/plotter/yields.py
+++ b/src/plotter/yields.py
@@ -1,0 +1,27 @@
+import ROOT
+
+def print_yields(hdata, hlistMC, ystr):
+    ystr += "Process\t\t\tN_Entries\t\tIntegral\t\tUnderflow\t\tOverflow\n"
+
+    hst_data = hdata.th
+    ystr += hdata.title+"\t\t"+str(hst_data.GetEntries())+"\t\t"+str(hst_data.Integral())+"\t\t"+str(hst_data.GetBinContent(0))+"\t\t"+str(hst_data.GetBinContent(hst_data.GetNbinsX()+1))+"\n"
+
+    for i in range(0,len(hlistMC)):
+        hMC = hlistMC[i].th
+        ystr += hlistMC[i].title+"\t\t"+str(hMC.GetEntries())+"\t\t"+str(hMC.Integral())+"\t\t"+str(hMC.GetBinContent(0))+"\t\t"+str(hMC.GetBinContent(hMC.GetNbinsX()+1))+"\n"
+
+    return ystr
+
+def print_yields_tex(title, hdata, hlistMC, ystr):
+    s1, s2, s3, s4 = "", "", "", ""
+    s1 = "\\documentclass{article}\n\\usepackage{array}\n\\usepackage{graphicx} % for \\resizebox\n\\begin{document}\n\\begin{table}[htbp]\n\\centering\n\\caption{"+title+"}\n\\resizebox{\\textwidth}{!}{%\n\\begin{tabular}{|c|c|c|c|c|}\n\\hline\nProcess & N\_Entries & Integral & Underflow & Overflow\\\\\n\\hline\n"
+    hst_data = hdata.th
+    s2 = str(hdata.title)+"&"+str(hst_data.GetEntries())+"&"+str(hst_data.Integral())+"&"+str(hst_data.GetBinContent(0))+"&"+str(hst_data.GetBinContent(hst_data.GetNbinsX()+1))+"\\\\\n"
+    for i in range(0,len(hlistMC)):
+        hMC = hlistMC[i].th
+        s3 += f"{hlistMC[i].title}&{hMC.GetEntries()}&{hMC.Integral()}&{hMC.GetBinContent(0)}&{hMC.GetBinContent(hst_data.GetNbinsX()+1)}\\\\\n"
+        
+    s4 = "\\hline\n\\end{tabular}%\n}\\label{tab:"+title+"_yields_table}\n\\end{table}\n\\end{document}"
+
+    ystr = s1+s2+s3+s4
+    return ystr

--- a/src/plotter/yields.py
+++ b/src/plotter/yields.py
@@ -1,4 +1,5 @@
 import ROOT
+from plotter import pdgRounding
 
 def print_yields(hdata, hlistMC, ystr):
     ystr += "Process\t\t\tN_Entries\t\tIntegral\t\tUnderflow\t\tOverflow\n"
@@ -14,12 +15,22 @@ def print_yields(hdata, hlistMC, ystr):
 
 def print_yields_tex(title, hdata, hlistMC, ystr):
     s1, s2, s3, s4 = "", "", "", ""
-    s1 = "\\documentclass{article}\n\\usepackage{array}\n\\usepackage{graphicx} % for \\resizebox\n\\begin{document}\n\\begin{table}[htbp]\n\\centering\n\\caption{"+title+"}\n\\resizebox{\\textwidth}{!}{%\n\\begin{tabular}{|c|c|c|c|c|}\n\\hline\nProcess & N\_Entries & Integral & Underflow & Overflow\\\\\n\\hline\n"
+    s1 = "\\documentclass{article}\n\\usepackage{array}\n\\usepackage{graphicx} % for \\resizebox\n\\begin{document}\n\\begin{table}[htbp]\n\\centering\n\\caption{"+title+"}\n\\resizebox{\\textwidth}{!}{%\n\\begin{tabular}{|c|c|c|c|c|}\n\\hline\nProcess & N\_Entries & Yield & Statistical unc. & Systematic unc.\\\\\n\\hline\n"
     hst_data = hdata.th
-    s2 = str(hdata.title)+"&"+str(hst_data.GetEntries())+"&"+str(hst_data.Integral())+"&"+str(hst_data.GetBinContent(0))+"&"+str(hst_data.GetBinContent(hst_data.GetNbinsX()+1))+"\\\\\n"
+    entries = hst_data.GetEntries()
+    err_entries = entries**0.5
+    integral = hst_data.Integral()+hst_data.GetBinContent(0)+hst_data.GetBinContent(hst_data.GetNbinsX()+1)
+    integral, err_entries = pdgRounding.pdgRound(integral, err_entries)
+
+    s2 = str(hdata.title)+"&"+str(entries)+"&"+str(integral)+"&"+str(err_entries)+"&NA\\\\\n"
     for i in range(0,len(hlistMC)):
         hMC = hlistMC[i].th
-        s3 += f"{hlistMC[i].title}&{hMC.GetEntries()}&{hMC.Integral()}&{hMC.GetBinContent(0)}&{hMC.GetBinContent(hst_data.GetNbinsX()+1)}\\\\\n"
+        entries = hMC.GetEntries()
+        err_entries = entries**0.5
+        integral = hMC.Integral()+hMC.GetBinContent(0)+hMC.GetBinContent(hMC.GetNbinsX()+1)
+        integral, err_entries = pdgRounding.pdgRound(integral, err_entries)
+
+        s3 += f"{hlistMC[i].title}&{entries}&{integral}&{err_entries}&NA\\\\\n"
         
     s4 = "\\hline\n\\end{tabular}%\n}\\label{tab:"+title+"_yields_table}\n\\end{table}\n\\end{document}"
 


### PR DESCRIPTION
Merge request to print "Run2" for the three years of data-taking campaign in the yields output instead of empty string. Also, creating a separate script to print yields in a text and .tex file, to be called from ExclWW_Plot repository.